### PR TITLE
Add example for multiple environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
 .DS_Store
+.idea

--- a/src/examples/load_secrets_for_multiple_doppler_configs.yml
+++ b/src/examples/load_secrets_for_multiple_doppler_configs.yml
@@ -1,0 +1,30 @@
+description: >
+  An example of a multi-environment workflow that loads secrets from different doppler configs in two separate jobs. 
+  Note a Doppler service token is required for each environment.  
+usage:
+  version: 2.1
+  orbs:
+    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3
+  jobs:
+    load_secrets_for_staging_deployment:
+      docker:
+        - image: cimg/base:current
+      steps:
+        - doppler-circleci/install
+        - doppler-circleci/load_secrets:
+            doppler_token: DOPPLER_TOKEN_STAGING
+        - run: echo -e "${SUPER_SECRET_PASSWORD}"
+    load_secrets_for_prod_deployment:
+      docker:
+        - image: cimg/base:current
+      steps:
+        - doppler-circleci/install
+        - doppler-circleci/load_secrets:
+            doppler_token: DOPPLER_TOKEN_PROD
+        - run: echo -e "${SUPER_SECRET_PASSWORD}"
+  workflows:
+    setup:
+      jobs:
+        - load_secrets_for_staging_deployment
+        - load_secrets_for_prod_deployment
+

--- a/src/examples/load_secrets_for_multiple_doppler_configs.yml
+++ b/src/examples/load_secrets_for_multiple_doppler_configs.yml
@@ -1,6 +1,6 @@
 description: >
-  An example of a multi-environment workflow that loads secrets from different doppler configs in two separate jobs. 
-  Note a Doppler service token is required for each environment.  
+  An example of a multi-environment workflow that loads secrets from different doppler configs in two separate jobs.
+  Note a Doppler service token is required for each environment.
 usage:
   version: 2.1
   orbs:
@@ -27,4 +27,3 @@ usage:
       jobs:
         - load_secrets_for_staging_deployment
         - load_secrets_for_prod_deployment
-

--- a/src/examples/use-orb-with-standard-linux-container.yml
+++ b/src/examples/use-orb-with-standard-linux-container.yml
@@ -16,6 +16,6 @@ usage:
             name: Print out doppler secret as an environment variable
             command: echo -e "${SUPER_SECRET_PASSWORD}"
 workflows:
-    setup:
-      jobs:
-        - use-orb-with-standard-linux-container
+  setup:
+    jobs:
+      - use-orb-with-standard-linux-container


### PR DESCRIPTION
## Why?

Various individuals have been asking how to use doppler secrets multiple configs. The typical example being deployment to different environments. 

## What?

Added a usage example demonstrating a pipeline with 2 jons, each job utilising a different Doppler config.

