### PR TITLE
Fix issue 9

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -44,12 +44,12 @@ jobs:
               echo "Test failed: DOPPLER_PROJECT has been set."
               exit 1
             fi
-            if [ $DOPPLER_CONFIG]
+            if [ $DOPPLER_CONFIG ]
             then
               echo "Test failed: DOPPLER_CONFIG has been set."
               exit 1
             fi
-            if [ $DOPPLER_ENVIRONMENT]
+            if [ $DOPPLER_ENVIRONMENT ]
             then
               echo "Test failed: DOPPLER_ENVIRONMENT has been set."
               exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,14 +97,6 @@ jobs:
               exit 1
             fi
             echo "All tests passed."
-      - run:
-          name: Assert environment variables set up as expected
-          command: |
-            if [ -z "$SUPER_SECRET_PASSWORD" ]
-            then
-              echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
-              exit 1
-            fi
 
   command-test-load-secrets-from-two-configs:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -34,22 +34,22 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
-            if [ -z $SUPER_SECRET_PASSWORD ]
+            if [ -z "$SUPER_SECRET_PASSWORD" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
               exit 1
             fi
-            if [ $DOPPLER_PROJECT ]
+            if [ "$DOPPLER_PROJECT" ]
             then
               echo "Test failed: DOPPLER_PROJECT has been set."
               exit 1
             fi
-            if [ $DOPPLER_CONFIG ]
+            if [ "$DOPPLER_CONFIG" ]
             then
               echo "Test failed: DOPPLER_CONFIG has been set."
               exit 1
             fi
-            if [ $DOPPLER_ENVIRONMENT ]
+            if [ "$DOPPLER_ENVIRONMENT" ]
             then
               echo "Test failed: DOPPLER_ENVIRONMENT has been set."
               exit 1
@@ -70,23 +70,22 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
-            source $BASH_ENV && echo -e "${SUPER_SECRET_PASSWORD}"
             if [ x"${SUPER_SECRET_PASSWORD}" == "x" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
               exit 1
             fi
-            if [ $DOPPLER_PROJECT ]
+            if [ "$DOPPLER_PROJECT" ]
             then
               echo "Test failed: DOPPLER_PROJECT has been set."
               exit 1
             fi
-            if [ $DOPPLER_CONFIG ]
+            if [ "$DOPPLER_CONFIG" ]
             then
               echo "Test failed: DOPPLER_CONFIG has been set."
               exit 1
             fi
-            if [ $DOPPLER_ENVIRONMENT ]
+            if [ "$DOPPLER_ENVIRONMENT" ]
             then
               echo "Test failed: DOPPLER_ENVIRONMENT has been set."
               exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -39,6 +39,11 @@ jobs:
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
               exit 1
             fi
+            if [ -z "$SUPER_SECRET_KEY" ]
+            then
+              echo "Test failed: SUPER_SECRET_KEY has not been set."
+              exit 1
+            fi
             if [ "$DOPPLER_PROJECT" ]
             then
               echo "Test failed: DOPPLER_PROJECT has been set."
@@ -92,6 +97,14 @@ jobs:
               exit 1
             fi
             echo "All tests passed."
+      - run:
+          name: Assert environment variables set up as expected
+          command: |
+            if [ -z "$SUPER_SECRET_PASSWORD" ]
+            then
+              echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
+              exit 1
+            fi
 
   command-test-load-secrets-from-two-configs:
     docker:
@@ -104,7 +117,19 @@ jobs:
           doppler_token: DOPPLER_TOKEN
       - doppler-circleci/load_secrets:
           doppler_token: DOPPLER_TOKEN_2
-
+      - run:
+          name: Assert environment variables set up as expected
+          command: |
+            if [ -z "$SUPER_SECRET_PASSWORD" ]
+            then
+              echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
+              exit 1
+            fi
+            if [ -z "$TEST_SECRET" ]
+            then
+              echo "Test failed: SUPER_SECRET_KEY has not been set."
+              exit 1
+            fi
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,6 +70,7 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
+            source $BASH_ENV
             if [ x"${SUPER_SECRET_PASSWORD}" == "x" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
-            if [ -z $SUPER_SECRET_PASSWORD ]
+            if [ x"${SUPER_SECRET_PASSWORD}" == "x" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
               exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
-            echo -e "${SUPER_SECRET_PASSWORD}"
+            source $BASH_ENV && echo -e "${SUPER_SECRET_PASSWORD}"
             if [ x"${SUPER_SECRET_PASSWORD}" == "x" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,18 +56,6 @@ jobs:
             fi
             echo "All tests passed."
 
-  command-test-load-secrets-twice:
-    docker:
-      - image: cimg/base:current
-    steps:
-      - checkout
-      # Run your orb's commands to validate them.
-      - doppler-circleci/install
-      - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_TOKEN
-      - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_TOKEN_2
-
   command-test-apk:
     docker:
       - image: alpine:latest
@@ -104,6 +92,18 @@ jobs:
             fi
             echo "All tests passed."
 
+  command-test-load-secrets-from-two-configs:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - doppler-circleci/install
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN_2
+
 workflows:
   test-deploy:
     jobs:
@@ -112,10 +112,10 @@ workflows:
       - command-test-apt:
           context: circleci-orb-publishing
           filters: *filters
-      - command-test-load-secrets-twice:
+      - command-test-apk:
           context: circleci-orb-publishing
           filters: *filters
-      - command-test-apk:
+      - command-test-load-secrets-from-two-configs:
           context: circleci-orb-publishing
           filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
@@ -130,6 +130,6 @@ workflows:
             - orb-tools/pack
             - command-test-apt
             - command-test-apk
-            - command-load-secrets-twice
+            - command-test-load-secrets-from-two-configs
           context: circleci-orb-publishing
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,6 +56,18 @@ jobs:
             fi
             echo "All tests passed."
 
+  command-test-load-secrets-twice:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - doppler-circleci/install
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN_2
+
   command-test-apk:
     docker:
       - image: alpine:latest
@@ -67,12 +79,40 @@ jobs:
       - run:
           name: Print out doppler secret as an environment variable
           command: source $BASH_ENV && echo -e "${SUPER_SECRET_PASSWORD}"
+      - run:
+          name: Assert environment variables set up as expected
+          command: |
+            if [ -z $SUPER_SECRET_PASSWORD ]
+            then
+              echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
+              exit 1
+            fi
+            if [ $DOPPLER_PROJECT ]
+            then
+              echo "Test failed: DOPPLER_PROJECT has been set."
+              exit 1
+            fi
+            if [ $DOPPLER_CONFIG ]
+            then
+              echo "Test failed: DOPPLER_CONFIG has been set."
+              exit 1
+            fi
+            if [ $DOPPLER_ENVIRONMENT ]
+            then
+              echo "Test failed: DOPPLER_ENVIRONMENT has been set."
+              exit 1
+            fi
+            echo "All tests passed."
+
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       # Test your orb's commands in a custom job and test your orb's jobs directly as a part of this workflow.
       - command-test-apt:
+          context: circleci-orb-publishing
+          filters: *filters
+      - command-test-load-secrets-twice:
           context: circleci-orb-publishing
           filters: *filters
       - command-test-apk:
@@ -90,5 +130,6 @@ workflows:
             - orb-tools/pack
             - command-test-apt
             - command-test-apk
+            - command-load-secrets-twice
           context: circleci-orb-publishing
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,6 +70,7 @@ jobs:
       - run:
           name: Assert environment variables set up as expected
           command: |
+            echo -e "${SUPER_SECRET_PASSWORD}"
             if [ x"${SUPER_SECRET_PASSWORD}" == "x" ]
             then
               echo "Test failed: SUPER_SECRET_PASSWORD has not been set."

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -32,8 +32,29 @@ jobs:
       - doppler-circleci/install
       - doppler-circleci/load_secrets
       - run:
-          name: Print out doppler secret as an environment variable
-          command: echo -e "${SUPER_SECRET_PASSWORD}"
+          name: Assert environment variables set up as expected
+          command: |
+            if [ -z $SUPER_SECRET_PASSWORD ]
+            then
+              echo "Test failed: SUPER_SECRET_PASSWORD has not been set."
+              exit 1
+            fi
+            if [ $DOPPLER_PROJECT ]
+            then
+              echo "Test failed: DOPPLER_PROJECT has been set."
+              exit 1
+            fi
+            if [ $DOPPLER_CONFIG]
+            then
+              echo "Test failed: DOPPLER_CONFIG has been set."
+              exit 1
+            fi
+            if [ $DOPPLER_ENVIRONMENT]
+            then
+              echo "Test failed: DOPPLER_ENVIRONMENT has been set."
+              exit 1
+            fi
+            echo "All tests passed."
 
   command-test-apk:
     docker:

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
-./doppler secrets download -t "${TOKEN}" --no-file --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' > .circleci/.dopplerenv
+
+./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' > .circleci/.dopplerenv
+
 sed -e 's/^/export /' .circleci/.dopplerenv >> "$BASH_ENV"
 # shellcheck disable=SC1090
 source "$BASH_ENV"

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -2,9 +2,9 @@
 
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
-SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=')
+SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
 
-for secret in $SECRETS; do
+for secret in $(echo $SECRETS | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT='); do
     echo "export $secret" >> "$BASH_ENV"
 done
 

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -2,11 +2,11 @@
 
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
-SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
+SECRETS=$(doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
 
-for secret in $(echo "$SECRETS" | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT='); do
-    echo "export $secret" >> "$BASH_ENV"
-done
+while IFS= read -r secret; do
+  echo "export $secret" >> "$BASH_ENV"
+done < <(printf '%s' "$SECRETS" | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=')
 
 # shellcheck disable=SC1090
 source "$BASH_ENV"

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -2,7 +2,7 @@
 
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
-SECRETS=$(doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
+SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
 
 while IFS= read -r secret; do
   echo "export $secret" >> "$BASH_ENV"

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -2,9 +2,11 @@
 
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
-./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' > .circleci/.dopplerenv
+SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=')
 
-sed -e 's/^/export /' .circleci/.dopplerenv >> "$BASH_ENV"
+for secret in "$SECRETS"; do
+    echo "export $secret" >> "$BASH_ENV"
+done
+
 # shellcheck disable=SC1090
 source "$BASH_ENV"
-rm .circleci/.dopplerenv

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
-./doppler secrets download -t "${TOKEN}" --no-file --format env > dopplerenv
-sed -e 's/^/export /' dopplerenv | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' >> "$BASH_ENV"
+./doppler secrets download -t "${TOKEN}" --no-file --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' > .circleci/.dopplerenv
+sed -e 's/^/export /' .circleci/.dopplerenv >> "$BASH_ENV"
 # shellcheck disable=SC1090
 source "$BASH_ENV"
+rm .circleci/.dopplerenv

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -4,7 +4,7 @@ TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
 SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env)
 
-for secret in $(echo $SECRETS | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT='); do
+for secret in $(echo "$SECRETS" | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT='); do
     echo "export $secret" >> "$BASH_ENV"
 done
 

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -4,7 +4,7 @@ TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 
 SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --format env | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=')
 
-for secret in "$SECRETS"; do
+for secret in $SECRETS; do
     echo "export $secret" >> "$BASH_ENV"
 done
 

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 TOKEN=$(eval echo "\$$DOPPLER_TOKEN_NAME")
 ./doppler secrets download -t "${TOKEN}" --no-file --format env > dopplerenv
-sed -e 's/^/export /' dopplerenv >> "$BASH_ENV"
+sed -e 's/^/export /' dopplerenv | grep -v '^DOPPLER_PROJECT=\|^DOPPLER_CONFIG=\|^DOPPLER_ENVIRONMENT=' >> "$BASH_ENV"
 # shellcheck disable=SC1090
 source "$BASH_ENV"


### PR DESCRIPTION
## Why?

The existing orb was unable to load_secrets from multiple configs as the doppler secrets download command included 3 doppler specific variables (DOPPLER_PROJECT, DOPPLER_ENVIRONMENT and DOPPLER_CONFIG) which the orb was then exporting to BASH_ENV. This affected subsequent usage of the doppler cli and caused failures when trying to download secrets from a difference config. 

## What?

The doppler secrets download command uses a token, and as such adding the --no-read-env command avoids accidentally utilising any of the 3 environment variables. This minimises unexpected side effects.

The export secrets to bash env step was updated to filter out the 3 DOPPLER variables so this orb will no longer export DOPPLER_PROJECT, DOPPLER_ENVIRONMENT or DOPPLER_CONFIG variables. This further minimises unexpected side effects. 

The export procedure no longer requires a dopplerenv file to be created, which avoids writing secrets unnessarily to the filesystem. 

Existing tests for apt and apk  now asssert that environment variables are set from secrets, and that the DOPPLER_PROJECT, DOPPLER_ENVIRONMENT and DOPPLER_CONFIG variables are not set.

A new test was added to check loading secrets from 2 separate configs and asserting that variables from each config are defined.


