### PR TITLE
Bumping version to 1.4 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the following to your CircleCI project config file (.circleci/config.yml) to
 
 ```yml
 orbs:
-    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3
+    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.4
 ```
 
 ### 3. Install Doppler CLI and load secrets


### PR DESCRIPTION
## Why?

Updates documentation to reference new version of orb.




