### PR TITLE
bump example version to latest 1.5.1

### DIFF
--- a/src/examples/load_secrets_for_multiple_doppler_configs.yml
+++ b/src/examples/load_secrets_for_multiple_doppler_configs.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3
+    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.5.1
   jobs:
     load_secrets_for_staging_deployment:
       docker:

--- a/src/examples/use-orb-with-alpine-container.yml
+++ b/src/examples/use-orb-with-alpine-container.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3
+    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.5.1
   jobs:
     use-orb-with-alpine-container:
       docker:

--- a/src/examples/use-orb-with-standard-linux-container.yml
+++ b/src/examples/use-orb-with-standard-linux-container.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3
+    doppler-circleci: ft-circleci-orbs/doppler-circleci@1.5.1
   jobs:
     use-orb-with-standard-linux-container:
       docker:


### PR DESCRIPTION
## Why?

We've released version 1.5.0 of the orb, but noticed that the versions are out of date (1.3). This fixes that.

## What?

- Bumped orb versions in the example to 1.5.1


