### PR TITLE
Fix unescaped double quotes

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -128,7 +128,7 @@ jobs:
               exit 1
             fi
 
-  command-test-load-multiline_secret:
+  command-test-load-multiline-secret:
     docker:
       - image: cimg/base:current
     steps:
@@ -187,7 +187,7 @@ workflows:
       - command-test-load-secrets-from-two-configs:
           context: circleci-orb-publishing
           filters: *filters
-      - command-test-load-multiline_secret:
+      - command-test-load-multiline-secret:
           context: circleci-orb-publishing
           filters: *filters
       - command-test-load-secret-with-double-quotes:
@@ -206,7 +206,7 @@ workflows:
             - command-test-apt
             - command-test-apk
             - command-test-load-secrets-from-two-configs
-            - command-test-load-multiline_secret
-            - command-test-load-secret-with-double_quotes
+            - command-test-load-multiline-secret
+            - command-test-load-secret-with-double-quotes
           context: circleci-orb-publishing
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -151,6 +151,28 @@ jobs:
               exit 1
             fi
 
+  command-test-load-secret-with-double-quotes:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - doppler-circleci/install
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN_DOUBLE_QUOTES
+      - run:
+          name: Assert environment variables set up as expected
+          command: |
+            source $BASH_ENV
+            echo "${SECRET_WITH_DOUBLE_QUOTES}"
+            expected_value='This is a "test string" which contains "double quotes"'
+            if [ "${SECRET_WITH_DOUBLE_QUOTES}" != "${expected_value}" ]
+            then
+              echo "Test failed: SECRET_WITH_DOUBLE_QUOTES has not been set as expected."
+              exit 1
+            fi
+
+
 workflows:
   test-deploy:
     jobs:
@@ -168,6 +190,9 @@ workflows:
       - command-test-load-multiline_secret:
           context: circleci-orb-publishing
           filters: *filters
+      - command-test-load-secret-with-double-quotes:
+          context: circleci-orb-publishing
+          filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
           filters: *release-filters
@@ -182,5 +207,6 @@ workflows:
             - command-test-apk
             - command-test-load-secrets-from-two-configs
             - command-test-load-multiline_secret
+            - command-test-load-secret-with-double_quotes
           context: circleci-orb-publishing
           filters: *release-filters

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -6,7 +6,7 @@ SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --for
 
 echo -E "${SECRETS}" |
   jq 'del(.DOPPLER_CONFIG, .DOPPLER_PROJECT, .DOPPLER_ENVIRONMENT)' |
-  jq -r 'to_entries[] | "export \(.key)=\"\(.value)\""' >> "$BASH_ENV"
+  jq -r 'to_entries[] |.value |= gsub("\""; "\\\"") | "export \(.key)=\"\(.value)\""' >> "$BASH_ENV"
 
 # shellcheck disable=SC1090
 source "$BASH_ENV"


### PR DESCRIPTION
## Why?

Any double quotes in secret values were causing the export statement to fail. 

## What?

Ensure all double quotes characters in secret values are escaped using the following jq expression 

`|.value |= gsub("\""; "\\\"")`

