### PR TITLE
Properly escape exports from the .env file using the jq @sh operator

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -172,6 +172,27 @@ jobs:
               exit 1
             fi
 
+  command-test-load-secret-with-dollar-signs:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - doppler-circleci/install
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN_DOLLAR_SIGNS
+      - run:
+          name: Assert environment variables set up as expected
+          command: |
+            source $BASH_ENV
+            echo "${SECRET_WITH_DOLLAR_SIGNS}"
+            expected_value='This is a "test string" which contains $DOLLAR $VALUES'
+            if [ "${SECRET_WITH_DOLLAR_SIGNS}" != "${expected_value}" ]
+            then
+              echo "Test failed: SECRET_WITH_DOLLAR_SIGNS has not been set as expected."
+              exit 1
+            fi
+
 
 workflows:
   test-deploy:
@@ -193,6 +214,9 @@ workflows:
       - command-test-load-secret-with-double-quotes:
           context: circleci-orb-publishing
           filters: *filters
+      - command-test-load-secret-with-dollar-signs:
+          context: circleci-orb-publishing
+          filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
           filters: *release-filters
@@ -208,5 +232,6 @@ workflows:
             - command-test-load-secrets-from-two-configs
             - command-test-load-multiline-secret
             - command-test-load-secret-with-double-quotes
+            - command-test-load-secret-with-dollar-signs
           context: circleci-orb-publishing
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -159,7 +159,7 @@ jobs:
       # Run your orb's commands to validate them.
       - doppler-circleci/install
       - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_TOKEN_DOUBLE_QUOTES
+          doppler_token: DOPPLER_TOKEN_SPECIAL_CHARACTERS
       - run:
           name: Assert environment variables set up as expected
           command: |
@@ -180,13 +180,13 @@ jobs:
       # Run your orb's commands to validate them.
       - doppler-circleci/install
       - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_TOKEN_DOLLAR_SIGNS
+          doppler_token: DOPPLER_TOKEN_SPECIAL_CHARACTERS
       - run:
           name: Assert environment variables set up as expected
           command: |
             source $BASH_ENV
             echo "${SECRET_WITH_DOLLAR_SIGNS}"
-            expected_value='This is a "test string" which contains $DOLLAR $VALUES'
+            expected_value='This is a "test string" which contains $DOLLAR $VALUES $$'
             if [ "${SECRET_WITH_DOLLAR_SIGNS}" != "${expected_value}" ]
             then
               echo "Test failed: SECRET_WITH_DOLLAR_SIGNS has not been set as expected."

--- a/src/scripts/load_secrets_to_env.sh
+++ b/src/scripts/load_secrets_to_env.sh
@@ -6,7 +6,7 @@ SECRETS=$(./doppler secrets download -t "${TOKEN}" --no-file --no-read-env --for
 
 echo -E "${SECRETS}" |
   jq 'del(.DOPPLER_CONFIG, .DOPPLER_PROJECT, .DOPPLER_ENVIRONMENT)' |
-  jq -r 'to_entries[] |.value |= gsub("\""; "\\\"") | "export \(.key)=\"\(.value)\""' >> "$BASH_ENV"
+  jq -r 'to_entries[] | .value |= @sh | "export \(.key)=\(.value)"' >> "$BASH_ENV"
 
 # shellcheck disable=SC1090
 source "$BASH_ENV"


### PR DESCRIPTION
## Summary
Fixes an issue with environment variable exports in the doppler-circleci-orb tool, where variables containing $$ (or other values that would be evaluated by the shell environment) were incorrectly evaluated as the process ID when using `source .env` to import the exports.

## Details
This change implements a fix that utilises the built-in [@sh filter](https://jqlang.github.io/jq/manual/#format-strings-and-escaping) in jq to escape each value properly and wraps entries in single quotes to prevent evaluation.

Docs for the filter state:
> The input is escaped suitable for use in a command-line for a POSIX shell. If the input is an array, the output will be a series of space-separated strings.

### Before
```
# Unexpectedly becomes "secret<Process ID>val" when sourced
export SECRET="secret$$val"
```

### After
```
# Stays our expected value "secret$$val" when sourced
export SECRET='secret$$val'
```