### PR TITLE
Update usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ jobs:
       - doppler-circleci/install
       - doppler-circleci/load_secrets
       - run:
-          name: Echo a Doppler secret after loading secrets
-          command: echo -e "${YOUR_DOPPLER_SECRET}"
+          name: Use the Doppler secret NPM_TOKEN to configure npm
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
 ```
 
 Secrets defined in the Doppler project **ci** environment will get configued as environment variables if everything is set up correctly. After load_secrets is executed, secrets will be accesible using the [CircleCI environment variables syntax](https://circleci.com/docs/env-vars/) e.g. ```${YOUR_DOPPLER_SECRET}```.
@@ -65,8 +65,8 @@ If you're using an Alpine based Docker image, when loading secrets an extra step
 
 ```yml
       - run:
-          name: Echo a Doppler secret after loading secrets
-          command: source $BASH_ENV && echo -e "${YOUR_DOPPLER_SECRET}"
+          name: Use the Doppler secret NPM_TOKEN to configure npm
+          command: source $BASH_ENV && echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
 ```
 
 ---

--- a/src/examples/load_secrets_for_multiple_doppler_configs.yml
+++ b/src/examples/load_secrets_for_multiple_doppler_configs.yml
@@ -13,7 +13,7 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets:
             doppler_token: DOPPLER_TOKEN_STAGING
-        - run: echo -e "${SUPER_SECRET_PASSWORD}"
+        - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
     load_secrets_for_prod_deployment:
       docker:
         - image: cimg/base:current
@@ -21,7 +21,7 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets:
             doppler_token: DOPPLER_TOKEN_PROD
-        - run: echo -e "${SUPER_SECRET_PASSWORD}"
+        - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
   workflows:
     setup:
       jobs:

--- a/src/examples/use-orb-with-alpine-container.yml
+++ b/src/examples/use-orb-with-alpine-container.yml
@@ -13,7 +13,7 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets
         - run:
-            name: Use the secret NPM_TOKEN from Doppler to configure npm 
+            name: Use the secret NPM_TOKEN from Doppler to configure npm
             command: source $BASH_ENV && echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
   workflows:
     setup:

--- a/src/examples/use-orb-with-alpine-container.yml
+++ b/src/examples/use-orb-with-alpine-container.yml
@@ -13,8 +13,8 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets
         - run:
-            name: Print out doppler secret as an environment variable
-            command: source $BASH_ENV && echo -e "${SUPER_SECRET_PASSWORD}" # Sourcing $BASH_ENV is required before executing any further commands
+            name: Use the secret NPM_TOKEN from Doppler to configure npm 
+            command: source $BASH_ENV && echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
   workflows:
     setup:
       jobs:

--- a/src/examples/use-orb-with-standard-linux-container.yml
+++ b/src/examples/use-orb-with-standard-linux-container.yml
@@ -13,7 +13,7 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets
         - run:
-            name: Use the secret NPM_TOKEN from Doppler to configure npm 
+            name: Use the secret NPM_TOKEN from Doppler to configure npm
             command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
 workflows:
   setup:

--- a/src/examples/use-orb-with-standard-linux-container.yml
+++ b/src/examples/use-orb-with-standard-linux-container.yml
@@ -13,8 +13,8 @@ usage:
         - doppler-circleci/install
         - doppler-circleci/load_secrets
         - run:
-            name: Print out doppler secret as an environment variable
-            command: echo -e "${SUPER_SECRET_PASSWORD}"
+            name: Use the secret NPM_TOKEN from Doppler to configure npm 
+            command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
 workflows:
   setup:
     jobs:


### PR DESCRIPTION
## Why?

- Echoing secrets is poor practice, therefore updating examples to not do that. 

## What?

- Updated examples to show configuration of npm rather than echoing secret

